### PR TITLE
[execution26 repo] Update docs: org renamed to bemanproject

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-# code owners for reviews on PRs
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Codeowners for reviews on PRs
 
-*	@dietmarkuehl
+*  @dietmarkuehl @camio @neatudarius
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ e.g.:
 ## Help Welcome!
 
 There are plenty of things which need to be done. Some of these
-are listed in the [issues section](https://github.com/beman-project/execution26/issues).
+are listed in the [issues section](https://github.com/bemanproject/execution26/issues).
 Other contributions are, of course, also welcome. Aside from contributing
 code the project welcomes reports on usage experience, code reviews, defect
 reports, features requests, etc. There are plenty contribution opportunities.
@@ -51,7 +51,7 @@ for contributing to the library.
 
 | Library | Linux | MacOS | Windows |
 | ------- | ----- | ----- | ------- |
-| build | ![Linux build status](https://github.com/beman-project/execution26/actions/workflows/linux.yml/badge.svg) | ![MacOS build status](https://github.com/beman-project/execution26/actions/workflows/macos.yml/badge.svg) | ![Window build status](https://github.com/beman-project/execution26/actions/workflows/windows.yml/badge.svg) |
+| build | ![Linux build status](https://github.com/bemanproject/execution26/actions/workflows/linux.yml/badge.svg) | ![MacOS build status](https://github.com/bemanproject/execution26/actions/workflows/macos.yml/badge.svg) | ![Window build status](https://github.com/bemanproject/execution26/actions/workflows/windows.yml/badge.svg) |
 
 The following instructions build the library and the examples:
 

--- a/include/beman/execution26/detail/common.hpp
+++ b/include/beman/execution26/detail/common.hpp
@@ -22,7 +22,7 @@
 
 /*!
  * \namespace beman
- * \brief Namespace for Beman projects http://github.com/beman-project/beman
+ * \brief Namespace for Beman projects http://github.com/bemanproject/beman
  * \headerfile beman/execution26/execution.hpp <beman/execution26/execution.hpp>
  */
 namespace beman {


### PR DESCRIPTION
https://github.com/bemanproject/beman/issues/65
https://github.com/bemanproject/beman/issues/67

