### PR TITLE
added a module and corresponding tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "In-source builds are not allowed!")
 endif()
 
+set(CMAKE_CXX_SCAN_FOR_MODULES ON)
 set(TARGET_NAME execution26)
 set(TARGET_NAMESPACE beman) # FIXME: not used in install(EXPORT ...) CK?
 set(TARGET_PREFIX ${TARGET_NAMESPACE}.${TARGET_NAME})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,7 @@
 list(
   APPEND
   EXAMPLES
+  modules
   playground
   sender-demo
   when_all-cancel

--- a/examples/modules.cpp
+++ b/examples/modules.cpp
@@ -1,0 +1,14 @@
+// examples/modules.cpp                                               -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// import std;
+#include <iostream>
+#if __cpp_modules < 201907L
+#include <beman/execution26/execution.hpp>
+#else
+import beman.execution26;
+#endif
+
+namespace ex = beman::execution26;
+
+int main() {}

--- a/include/beman/execution26/execution.hpp
+++ b/include/beman/execution26/execution.hpp
@@ -20,6 +20,7 @@
 #include <beman/execution26/detail/operation_state.hpp>
 #include <beman/execution26/detail/sender.hpp>
 #include <beman/execution26/detail/sender_in.hpp>
+//-dk:TODO #include <beman/execution26/detail/sender_to.hpp>
 #include <beman/execution26/detail/scheduler.hpp>
 #include <beman/execution26/detail/receiver.hpp>
 #include <beman/execution26/detail/valid_completion_for.hpp>
@@ -37,6 +38,7 @@
 #include <beman/execution26/detail/start.hpp>
 #include <beman/execution26/detail/connect.hpp>
 #include <beman/execution26/detail/schedule.hpp>
+#include <beman/execution26/detail/schedule_result_t.hpp>
 
 #include <beman/execution26/detail/continues_on.hpp>
 #include <beman/execution26/detail/into_variant.hpp>

--- a/src/beman/execution26/CMakeLists.txt
+++ b/src/beman/execution26/CMakeLists.txt
@@ -16,7 +16,6 @@ cmake_print_variables(TARGET_ALIAS TARGET_LIBRARY TARGET_PREFIX PROJECT_SOURCE_D
 
 target_sources(
   ${TARGET_LIBRARY}
-  PRIVATE execution.cpp
   PUBLIC FILE_SET
          ${TARGET_LIBRARY}_public_headers
          TYPE
@@ -188,6 +187,13 @@ target_compile_features(${TARGET_LIBRARY} PUBLIC
   "$<$<NOT:$<COMPILE_FEATURES:cxx_std_26>>:cxx_std_23>"
 )
 
+target_sources(
+  beman_execution26
+  PUBLIC FILE_SET
+         beman_execution26 TYPE CXX_MODULES FILES execution.cpp
+)
+
+if(FALSE)
 install(
   TARGETS ${TARGET_LIBRARY}
   EXPORT ${TARGETS_EXPORT_NAME}1
@@ -195,7 +201,6 @@ install(
   FILE_SET ${TARGET_LIBRARY}_public_headers
   FILE_SET ${TARGET_LIBRARY}_detail_headers
 )
-# cmake-format: on
 
 install(
   EXPORT ${TARGETS_EXPORT_NAME}1
@@ -203,3 +208,13 @@ install(
   DESTINATION "${INSTALL_CONFIGDIR}"
   NAMESPACE ${TARGET_LIBRARY}::
 )
+
+#-dk:TODO build/default/src/beman/execution26/CMakeFiles/beman_execution26.dir/beman.execution26.pcm
+install(
+  TARGETS beman_execution26
+  EXPORT beman_execution26
+  COMPONENT FILE_SET beman_execution26
+  DESTINATION lib/beman/execution26
+)
+endif()
+# cmake-format: on

--- a/src/beman/execution26/execution.cpp
+++ b/src/beman/execution26/execution.cpp
@@ -2,6 +2,221 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // ----------------------------------------------------------------------------
 
+module;
+#include <execution>
+#include <stop_token>
+#include <beman/execution26/execution.hpp>
+#include <beman/execution26/stop_token.hpp>
+
+export module beman.execution26;
+
 namespace beman::execution26 {
-int version{000};
-}
+export int version(0);
+// [stoptoken.concepts], stop token concepts
+export using ::beman::execution26::stoppable_token;
+export using ::beman::execution26::unstoppable_token;
+
+// [stoptoken], class stop_token
+export using ::beman::execution26::stop_token;
+
+// [stopsource], class stop_source
+export using ::beman::execution26::stop_source;
+
+// no-shared-stop-state indicator
+//-dk:TODO export using ::beman::execution26::no_stop_state_t;
+
+// [stopcallback], class template stop_callback
+export using ::beman::execution26::stop_callback;
+
+// [stoptoken.never], class never_stop_token
+export using ::beman::execution26::never_stop_token;
+
+// [stoptoken.inplace], class inplace_stop_token
+export using ::beman::execution26::inplace_stop_token;
+
+// [stopsource.inplace], class inplace_stop_source
+export using ::beman::execution26::inplace_stop_source;
+
+// [stopcallback.inplace], class template inplace_stop_callback
+export using ::beman::execution26::inplace_stop_callback;
+export using ::beman::execution26::stop_callback_for_t;
+
+#if 0
+    //-dk:TODO enable the execution policies
+    export using ::std::is_execution_policy;
+    export using ::std::is_execution_policy_v;
+
+    export using ::std::execution::sequenced_policy;
+    export using ::std::execution::parallel_policy;
+    export using ::std::execution::parallel_unsequenced_policy;
+    export using ::std::execution::unsequenced_policy;
+
+    export using ::std::execution::seq;
+    export using ::std::execution::par;
+    export using ::std::execution::par_unseq;
+    export using ::std::execution::unseq;
+#endif
+
+// [exec.queries], queries
+export using ::beman::execution26::forwarding_query_t;
+export using ::beman::execution26::get_allocator_t;
+export using ::beman::execution26::get_stop_token_t;
+
+export using ::beman::execution26::forwarding_query;
+export using ::beman::execution26::get_allocator;
+export using ::beman::execution26::get_stop_token;
+
+export using ::beman::execution26::stop_token_of_t;
+
+export using ::beman::execution26::get_domain_t;
+export using ::beman::execution26::get_scheduler_t;
+export using ::beman::execution26::get_delegation_scheduler_t;
+//-dk:TODO export using ::beman::execution26::get_forward_progress_guarantee_t;
+export using ::beman::execution26::get_completion_scheduler_t;
+
+export using ::beman::execution26::get_domain;
+export using ::beman::execution26::get_scheduler;
+export using ::beman::execution26::get_delegation_scheduler;
+//-dk:TODO export using ::beman::execution26::forward_progress_guarantee;
+//-dk:TODO export using ::beman::execution26::get_forward_progress_guarantee;
+export using ::beman::execution26::get_completion_scheduler;
+
+export using ::beman::execution26::empty_env;
+export using ::beman::execution26::get_env_t;
+export using ::beman::execution26::get_env;
+
+export using ::beman::execution26::env_of_t;
+
+// [exec.domain.default], execution_domains
+export using ::beman::execution26::default_domain;
+
+// [exec.sched], schedulers
+export using ::beman::execution26::scheduler_t;
+export using ::beman::execution26::scheduler;
+
+// [exec.recv], receivers
+export using ::beman::execution26::receiver_t;
+export using ::beman::execution26::receiver;
+export using ::beman::execution26::receiver_of;
+
+export using ::beman::execution26::set_value_t;
+export using ::beman::execution26::set_error_t;
+export using ::beman::execution26::set_stopped_t;
+
+export using ::beman::execution26::set_value;
+export using ::beman::execution26::set_error;
+export using ::beman::execution26::set_stopped;
+
+// [exec.opstate], operation states
+export using ::beman::execution26::operation_state_t;
+export using ::beman::execution26::operation_state;
+export using ::beman::execution26::start_t;
+export using ::beman::execution26::start;
+
+// [exec.snd], senders
+export using ::beman::execution26::sender_t;
+export using ::beman::execution26::sender;
+export using ::beman::execution26::sender_in;
+//-dk:TODO export using ::beman::execution26::sender_to;
+
+// [exec.getcomplsigs], completion signatures
+export using ::beman::execution26::get_completion_signatures_t;
+export using ::beman::execution26::get_completion_signatures;
+export using ::beman::execution26::completion_signatures_of_t;
+export using ::beman::execution26::value_types_of_t;
+export using ::beman::execution26::error_types_of_t;
+export using ::beman::execution26::sends_stopped;
+export using ::beman::execution26::tag_of_t;
+
+// [exec.snd.transform], sender transformations
+export using ::beman::execution26::transform_sender;
+
+// [exec.snd.transform.env], environment transformations
+//-dk:TODO export using ::beman::execution26::transform_env;
+
+// [exec.snd.apply], sender algorithm application
+export using ::beman::execution26::apply_sender;
+
+// [exec.connect], the connect sender algorithm
+export using ::beman::execution26::connect_t;
+export using ::beman::execution26::connect;
+export using ::beman::execution26::connect_result_t;
+
+// [exec.factories], sender factories
+export using ::beman::execution26::just_t;
+export using ::beman::execution26::just_error_t;
+export using ::beman::execution26::just_stopped_t;
+export using ::beman::execution26::schedule_t;
+
+export using ::beman::execution26::just;
+export using ::beman::execution26::just_error;
+export using ::beman::execution26::just_stopped;
+export using ::beman::execution26::schedule;
+export using ::beman::execution26::read_env;
+
+export using ::beman::execution26::schedule_result_t;
+
+// [exec.adapt], sender adaptors
+export using ::beman::execution26::sender_adaptor_closure;
+
+export using ::beman::execution26::starts_on_t;
+export using ::beman::execution26::continues_on_t;
+//-dk:TODO export using ::beman::execution26::on_t;
+export using ::beman::execution26::schedule_from_t;
+export using ::beman::execution26::then_t;
+export using ::beman::execution26::upon_error_t;
+export using ::beman::execution26::upon_stopped_t;
+export using ::beman::execution26::let_value_t;
+export using ::beman::execution26::let_error_t;
+export using ::beman::execution26::let_stopped_t;
+//-dk:TODO export using ::beman::execution26::bulk_t;
+//-dk:TODO export using ::beman::execution26::split_t;
+export using ::beman::execution26::when_all_t;
+export using ::beman::execution26::when_all_with_variant_t;
+export using ::beman::execution26::into_variant_t;
+//-dk:TODO export using ::beman::execution26::stopped_as_optional_t;
+//-dk:TODO export using ::beman::execution26::stopped_as_error_t;
+
+export using ::beman::execution26::starts_on;
+export using ::beman::execution26::continues_on;
+//-dk:TODO export using ::beman::execution26::on;
+export using ::beman::execution26::schedule_from;
+export using ::beman::execution26::then;
+export using ::beman::execution26::upon_error;
+export using ::beman::execution26::upon_stopped;
+export using ::beman::execution26::let_value;
+export using ::beman::execution26::let_error;
+export using ::beman::execution26::let_stopped;
+//-dk:TODO export using ::beman::execution26::bulk;
+//-dk:TODO export using ::beman::execution26::split;
+export using ::beman::execution26::when_all;
+export using ::beman::execution26::when_all_with_variant;
+export using ::beman::execution26::into_variant;
+//-dk:TODO export using ::beman::execution26::stopped_as_optional;
+//-dk:TODO export using ::beman::execution26::stopped_as_error;
+
+// [exec.util.cmplsig]
+export using ::beman::execution26::completion_signatures;
+
+// [exec.util.cmplsig.trans]
+//-dk:TODO export using ::beman::execution26::transform_completion_signatures;
+//-dk:TODO export using ::beman::execution26::transform_completion_signatures_of;
+
+// [exec.run.loop], run_loop
+export using ::beman::execution26::run_loop;
+
+// [exec.consumers], consumers
+export using ::beman::execution26::sync_wait_t;
+//-dk:TODO export using ::beman::execution26::sync_wait_with_variant_t;
+
+export using ::beman::execution26::sync_wait;
+//-dk:TODO export using ::beman::execution26::sync_wait_with_variant;
+
+// [exec.as.awaitable]
+//-dk:TODO export using ::beman::execution26::as_awaitable_t;
+//-dk:TODO export using ::beman::execution26::as_awaitable;
+
+// [exec.with.awaitable.senders]
+//-dk:TODO export using ::beman::execution26::with_awaitable_senders;
+
+} // namespace beman::execution26

--- a/tests/beman/execution26/CMakeLists.txt
+++ b/tests/beman/execution26/CMakeLists.txt
@@ -11,6 +11,13 @@ endif()
 list(
   APPEND
   execution_tests
+  execution-module.test
+  stop-token-module.test
+)
+
+list(
+  APPEND
+  xexecution_tests
   notify.test
   exec-scounting.test
   exec-awaitable.test
@@ -126,6 +133,7 @@ foreach(test ${execution_tests})
   add_test(NAME ${TEST_EXE} COMMAND $<TARGET_FILE:${TEST_EXE}>)
 endforeach()
 
+if(FALSE)
 if(NOT PROJECT_IS_TOP_LEVEL)
   # test if the targets are findable from the build directory
   # cmake-format: off
@@ -147,4 +155,5 @@ if(NOT PROJECT_IS_TOP_LEVEL)
           # TODO(CK): Needed too? "--config $<CONFIG>"
   )
   # cmake-format: on
+endif()
 endif()

--- a/tests/beman/execution26/execution-module.test.cpp
+++ b/tests/beman/execution26/execution-module.test.cpp
@@ -1,0 +1,194 @@
+// tests/beman/execution26/execution-module.test.cpp                  -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <test/execution.hpp>
+#if 0
+#include <beman/execution26/execution.hpp>
+#else
+import beman.execution26;
+#endif
+
+// ----------------------------------------------------------------------------
+
+namespace {
+// [exec.getcomplsigs], completion signatures
+template <typename S>
+using value_types_of_t = test_stdex::value_types_of_t<S>;
+template <typename S>
+using error_types_of_t = test_stdex::error_types_of_t<S>;
+} // namespace
+
+TEST(execution_modules) {
+#if 0
+    //-dk:TOD enable execution policies
+    test::use_type<test_std::sequenced_policy>();
+    test::use_type<test_std::parallel_policy>();
+    test::use_type<test_std::parallel_unsequenced_policy>();
+    test::use_type<test_std::unsequenced_policy>();
+
+    test::use(test_std::seq);
+    test::use(test_std::par);
+    test::use(test_std::par_unseq);
+    test::use(test_std::unseq);
+#endif
+    // [exec.queries], queries
+    test::use_type<test_std::forwarding_query_t>();
+    test::use_type<test_std::get_allocator_t>();
+    test::use_type<test_std::get_stop_token_t>();
+
+    test::use_type<test_std::forwarding_query_t>();
+    test::use_type<test_std::get_allocator_t>();
+    test::use_type<test_std::get_stop_token_t>();
+
+    test::use_template<test_std::stop_token_of_t>();
+
+    test::use_type<test_stdex::get_domain_t>();
+    test::use_type<test_stdex::get_scheduler_t>();
+    test::use_type<test_stdex::get_delegation_scheduler_t>();
+    //-dk:TODO test::use_type<test_stdex::get_forward_progress_guarantee_t>();
+    test::use_template<test_stdex::get_completion_scheduler_t>();
+
+    test::use(test_stdex::get_domain);
+    test::use(test_stdex::get_scheduler);
+    test::use(test_stdex::get_delegation_scheduler);
+    //-dk:TODO test::use_type<test_stdex::forward_progress_guarantee>();
+    //-dk:TODO test::use(test_stdex::get_forward_progress_guarantee);
+    test::use(test_stdex::get_completion_scheduler<test_stdex::set_value_t>);
+
+    test::use_type<test_stdex::empty_env>();
+    test::use_type<test_stdex::get_env_t>();
+    test::use(test_stdex::get_env);
+    test::use_template<test_stdex::env_of_t>();
+
+    // [exec.domain.default], execution_domains
+    test::use_type<test_stdex::default_domain>();
+
+    // [exec.sched], schedulers
+    test::use_type<test_stdex::scheduler_t>();
+    static_assert(not test_stdex::scheduler<int>);
+
+    // [exec.recv], receivers
+    test::use_type<test_stdex::receiver_t>();
+    static_assert(not test_stdex::receiver<int>);
+    static_assert(not test_stdex::receiver_of<int, test_stdex::completion_signatures<>>);
+
+    test::use_type<test_stdex::set_value_t>();
+    test::use_type<test_stdex::set_error_t>();
+    test::use_type<test_stdex::set_stopped_t>();
+
+    test::use(test_stdex::set_value);
+    test::use(test_stdex::set_error);
+    test::use(test_stdex::set_stopped);
+
+    // [exec.opstate], operation states
+    test::use_type<test_stdex::operation_state_t>();
+    static_assert(not test_stdex::operation_state<int>);
+    test::use_type<test_stdex::start_t>();
+    test::use(test_stdex::start);
+
+    // [exec.snd], senders
+    test::use_type<test_stdex::sender_t>();
+    static_assert(not test_stdex::sender<int>);
+    static_assert(not test_stdex::sender_in<int>);
+    //-dk:TODO static_assert(not test_stdex::sender_to<int, int>);
+
+    // [exec.getcomplsigs], completion signatures
+    test::use_type<test_stdex::get_completion_signatures_t>();
+    test::use(test_stdex::get_completion_signatures);
+
+    test::use_template<test_stdex::completion_signatures_of_t>();
+    static_assert(not test_stdex::sends_stopped<decltype(test_stdex::just())>);
+    test::use_template<test_stdex::tag_of_t>();
+
+    // [exec.snd.transform], sender transformations
+    test_stdex::transform_sender(test_stdex::default_domain{}, test_stdex::just());
+
+    // [exec.snd.transform.env], environment transformations
+    //-dk:TODO test_stdex::transform_env(test_stdex::default_domain{}, test_stdex::just(), test_stdex::empty_env{});
+
+    // [exec.snd.apply], sender algorithm application
+    //-dk:TODO test_stdex::apply_sender(test_stdex::default_domain{}, test_stdex::just_t{}, test_stdex::just());
+
+    // [exec.connect], the connect sender algorithm
+    test::use_type<test_stdex::connect_t>();
+    test::use(test_stdex::connect);
+    test::use_template<test_stdex::connect_result_t>();
+
+    // [exec.factories], sender factories
+    test::use_type<test_stdex::just_t>();
+    test::use_type<test_stdex::just_error_t>();
+    test::use_type<test_stdex::just_stopped_t>();
+    test::use_type<test_stdex::schedule_t>();
+
+    test::use(test_stdex::just);
+    test::use(test_stdex::just_error);
+    test::use(test_stdex::just_stopped);
+    test::use(test_stdex::schedule);
+    test::use(test_stdex::read_env);
+
+    test::use_template<test_stdex::schedule_result_t>();
+
+    // [exec.adapt], sender adaptors
+    test::use_template<test_stdex::sender_adaptor_closure>();
+
+    test::use_type<test_stdex::starts_on_t>();
+    test::use_type<test_stdex::continues_on_t>();
+    //-dk:TODO test::use_type<test_stdex::on_t>();
+    test::use_type<test_stdex::schedule_from_t>();
+    test::use_type<test_stdex::then_t>();
+    test::use_type<test_stdex::upon_error_t>();
+    test::use_type<test_stdex::upon_stopped_t>();
+    test::use_type<test_stdex::let_value_t>();
+    test::use_type<test_stdex::let_error_t>();
+    test::use_type<test_stdex::let_stopped_t>();
+    //-dk:TODO test::use_type<test_stdex::bulk_t>();
+    //-dk:TODO test::use_type<test_stdex::split_t>();
+    test::use_type<test_stdex::when_all_t>();
+    test::use_type<test_stdex::when_all_with_variant_t>();
+    test::use_type<test_stdex::into_variant_t>();
+    //-dk:TODO test::use_type<test_stdex::stopped_as_optional_t>();
+    //-dk:TODO test::use_type<test_stdex::stopped_as_error_t>();
+
+    test::use(test_stdex::starts_on);
+    test::use(test_stdex::continues_on);
+    //-dk:TODO test::use(test_stdex::on);
+    test::use(test_stdex::schedule_from);
+    test::use(test_stdex::then);
+    test::use(test_stdex::upon_error);
+    test::use(test_stdex::upon_stopped);
+    test::use(test_stdex::let_value);
+    test::use(test_stdex::let_error);
+    test::use(test_stdex::let_stopped);
+    //-dk:TODO test::use(test_stdex::bulk);
+    //-dk:TODO test::use(test_stdex::split);
+    test::use(test_stdex::when_all);
+    test::use(test_stdex::when_all_with_variant);
+    test::use(test_stdex::into_variant);
+    //-dk:TODO test::use(test_stdex::stopped_as_optional);
+    //-dk:TODO test::use(test_stdex::stopped_as_error);
+
+    // [exec.util.cmplsig]
+    test::use_template<test_stdex::completion_signatures>();
+
+    // [exec.util.cmplsig.trans]
+    //-dk:TODO template <typename S> using transform_completion_signatures =
+    //test_stdex::transform_completion_signatures<S>; -dk:TODO template <typename S> using
+    //transform_completion_signatures_of = test_stdex::transform_completion_signatures_of<S>;
+
+    // [exec.run.loop], run_loop
+    test::use_type<test_stdex::run_loop>();
+
+    // [exec.consumers], consumers
+    test::use_type<test_std_this_thread::sync_wait_t>();
+    //-dk:TODO test::use_type<test_std_this_thread::sync_wait_with_variant_t>();
+
+    test::use(test_std_this_thread::sync_wait);
+    //-dk:TODO test::use(test_std_this_thread::sync_wait_with_variant);
+
+    // [exec.as.awaitable]
+    //-dk:TODO test::use_type<test_stdex::as_awaitable_t>();
+    //-dk:TODO test::use(test_stdex::as_awaitable);
+
+    // [exec.with.awaitable.senders]
+    //-dk:TODO test::use_template<test_stdex::with_awaitable_senders>();
+}

--- a/tests/beman/execution26/include/test/execution.hpp
+++ b/tests/beman/execution26/include/test/execution.hpp
@@ -4,7 +4,7 @@
 #ifndef INCLUDED_TEST_EXECUTION
 #define INCLUDED_TEST_EXECUTION
 
-#include <beman/execution26/stop_token.hpp>
+// #include <beman/execution26/stop_token.hpp>
 #include <concepts>
 #include <cstddef>
 
@@ -16,7 +16,11 @@
 
 namespace beman::execution26 {}
 
+namespace beman::execution26::detail {};
+
 namespace test_std    = ::beman::execution26;
+namespace test_stdex           = ::beman::execution26;
+namespace test_std_this_thread = ::beman::execution26;
 namespace test_detail = ::beman::execution26::detail;
 
 namespace test {
@@ -27,6 +31,10 @@ auto check_type(T1&&) {
     static_assert(std::same_as<T0, T1>);
 }
 
+template <template <typename...> class>
+auto use_template() {}
+template <typename...>
+auto use_type() {}
 auto use(auto&&...) noexcept -> void {}
 
 struct throws {

--- a/tests/beman/execution26/stop-token-module.test.cpp
+++ b/tests/beman/execution26/stop-token-module.test.cpp
@@ -1,0 +1,42 @@
+// tests/beman/execution26/stop-token-module.test.cpp                 -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <test/execution.hpp>
+#if 0
+#include <beman/execution26/execution.hpp>
+#else
+import beman.execution26;
+#endif
+
+// ----------------------------------------------------------------------------
+
+TEST(stop_token_modules) {
+    // [stoptoken.concepts], stop token concepts
+    static_assert(not test_std::stoppable_token<int>);
+    static_assert(not test_std::unstoppable_token<int>);
+
+    // [stoptoken], class stop_token
+    test::use_type<test_std::stop_token>();
+
+    // [stopsource], class stop_source
+    test::use_type<test_std::stop_source>();
+
+    // no-shared-stop-state indicator
+    //-dk:TODO test::use_type<test_std::no_stop_state_t>();
+
+    // [stopcallback], class template stop_callback
+    test::use_template<test_std::stop_callback>();
+
+    // [stoptoken.never], class never_stop_token
+    test::use_type<test_std::never_stop_token>();
+
+    // [stoptoken.inplace], class inplace_stop_token
+    test::use_type<test_std::inplace_stop_token>();
+
+    // [stopsource.inplace], class inplace_stop_source
+    test::use_type<test_std::inplace_stop_source>();
+
+    // [stopcallback.inplace], class template inplace_stop_callback
+    test::use_template<test_std::inplace_stop_callback>();
+    test::use_template<test_std::stop_callback_for_t>();
+}


### PR DESCRIPTION
The `CMakeLists.txt` aren't quite right, yet:

- some tests are disabled
- more importantly, the install doesn't work, yet - something is missing

Also, there is probably some suitable guard needed to avoid trying to compile modules when there isn't any support. It seems `clang++` has some level of implementation of modules but doesn't define the feature test macro. I haven't tried with `gcc` or MSVC++, yet.