### PR TITLE
exec-split: add a test with multiple children

### DIFF
--- a/include/beman/execution26/detail/decayed_type_list.hpp
+++ b/include/beman/execution26/detail/decayed_type_list.hpp
@@ -1,0 +1,20 @@
+// include/beman/execution26/detail/decayed_type_list.hpp             -*-C++-*-
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef INCLUDED_BEMAN_EXECUTION26_DETAIL_DECAYED_TYPE_LIST
+#define INCLUDED_BEMAN_EXECUTION26_DETAIL_DECAYED_TYPE_LIST
+
+#include "beman/execution26/detail/type_list.hpp"
+
+#include <type_traits>
+
+// ----------------------------------------------------------------------------
+
+namespace beman::execution26::detail {
+template <class... Args>
+using decayed_type_list = ::beman::execution26::detail::type_list<::std::decay_t<Args>...>;
+} // namespace beman::execution26::detail
+
+// ----------------------------------------------------------------------------
+
+#endif

--- a/include/beman/execution26/detail/split.hpp
+++ b/include/beman/execution26/detail/split.hpp
@@ -264,7 +264,7 @@ struct impls_for<split_impl_t> : ::beman::execution26::detail::default_impls {
         }
 
         void start() noexcept {
-            on_stop.emplace(::beman::execution26::get_stop_token(::beman::execution26::get_env(receiver)),
+            on_stop.emplace(::beman::execution26::get_stop_token(::beman::execution26::get_env(*receiver)),
                             on_stop_type{sh_state});
             sh_state->add_listener(this);
         }

--- a/include/beman/execution26/detail/when_all.hpp
+++ b/include/beman/execution26/detail/when_all.hpp
@@ -6,6 +6,7 @@
 
 #include <beman/execution26/detail/completion_signatures_of_t.hpp>
 #include <beman/execution26/detail/decayed_tuple.hpp>
+#include <beman/execution26/detail/decayed_type_list.hpp>
 #include <beman/execution26/detail/default_domain.hpp>
 #include <beman/execution26/detail/default_impls.hpp>
 #include <beman/execution26/detail/empty_env.hpp>
@@ -32,7 +33,6 @@
 #include <beman/execution26/detail/stop_callback_for_t.hpp>
 #include <beman/execution26/detail/stop_token_of_t.hpp>
 #include <beman/execution26/detail/transform_sender.hpp>
-#include <beman/execution26/detail/type_list.hpp>
 #include <beman/execution26/detail/type_list.hpp>
 #include <beman/execution26/detail/value_types_of_t.hpp>
 
@@ -108,9 +108,10 @@ struct impls_for<::beman::execution26::detail::when_all_t> : ::beman::execution2
                     ::std::exception_ptr,
                     ::beman::execution26::detail::meta::combine<::beman::execution26::detail::meta::to<
                         ::beman::execution26::detail::type_list,
-                        ::beman::execution26::detail::meta::combine<
-                            ::beman::execution26::
-                                error_types_of_t<Sender, env_t, ::beman::execution26::detail::type_list>...>>>>>>>;
+                        ::beman::execution26::detail::meta::combine<::beman::execution26::error_types_of_t<
+                            Sender,
+                            env_t,
+                            ::beman::execution26::detail::decayed_type_list>...>>>>>>>;
         using stop_callback = ::beman::execution26::stop_callback_for_t<
             ::beman::execution26::stop_token_of_t<::beman::execution26::env_of_t<Receiver>>,
             ::beman::execution26::detail::on_stop_request<state_type>>;


### PR DESCRIPTION
Also, fix some places that can't handle signatures that contain `set_error_t(std::exception_ptr)` and `set_error_t(const std::exception_ptr&)`